### PR TITLE
Add link preview disabling options across event conversations and ser…

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -32,6 +32,10 @@ import {
 import { ICONS } from './utils/iconUtils';
 import { escapeMarkdownV2Text } from './utils/markdownUtils';
 
+const disableLinkPreview = {
+  is_disabled: true,
+};
+
 export const bot = new Bot<MyContext>(getTelegramToken() || '', {
   client: {
     timeoutSeconds: 500,
@@ -70,7 +74,7 @@ bot.use(
     onLimitExceeded: async (ctx) => {
       await ctx.replyWithMarkdownV2(
         ctx.t('bot-entry-error-rate-limit-exceeded'),
-        {},
+        { link_preview_options: disableLinkPreview },
       );
     },
     keyGenerator: (ctx) => {
@@ -78,14 +82,6 @@ bot.use(
     },
   }),
 );
-
-// bot.use(async (ctx, next) => {
-//   if (ctx.session.locale) {
-//     console.log('Setting locale to', ctx.session.locale);
-//     await ctx.i18n.setLocale(ctx.session.locale);
-//   }
-//   await next();
-// });
 
 bot.catch(async (err) => {
   const ctx = err.ctx;
@@ -106,6 +102,7 @@ bot.catch(async (err) => {
         ctx.t('bot-entry-error-unknown', {
           errorcode: e instanceof GrammyError ? e.error_code : 'unbekannt',
         }),
+        { link_preview_options: disableLinkPreview },
       );
     } catch (replyError) {
       console.error('Error sending error message to user:', replyError);
@@ -120,27 +117,6 @@ bot.use(createConversation(searchEventConversation, 'searchEventConversation'));
 bot.use(createConversation(editEventConversation, 'editEventConversation'));
 bot.use(createConversation(deleteEventConversation, 'deleteEventConversation'));
 
-// bot.command('language', async (ctx) => {
-//   await ctx.replyWithMarkdownV2(ctx.t('bot-entry-choose-language'), {
-//     reply_markup: {
-//       inline_keyboard: [
-//         [
-//           {
-//             text: ctx.t('bot-entry-language-english'),
-//             callback_data: 'set_lang_en',
-//           },
-//         ],
-//         [
-//           {
-//             text: ctx.t('bot-entry-language-german'),
-//             callback_data: 'set_lang_de',
-//           },
-//         ],
-//       ],
-//     },
-//   });
-// });
-
 bot.command('submit', async (ctx) => {
   await ctx.replyWithMarkdownV2(
     ctx.t('bot-entry-submit-event', { icon: ICONS.event }),
@@ -148,6 +124,7 @@ bot.command('submit', async (ctx) => {
       reply_markup: new InlineKeyboard()
         .text(ctx.t('bot-entry-yes', { icon: ICONS.approve }), 'submit_event')
         .text(ctx.t('bot-entry-no', { icon: ICONS.reject }), 'cancel_submit'),
+      link_preview_options: disableLinkPreview,
     },
   );
 });
@@ -160,6 +137,7 @@ bot.command('search', async (ctx) => {
         ctx.t('bot-entry-start-search'),
         'start_search',
       ),
+      link_preview_options: disableLinkPreview,
     },
   );
 });
@@ -169,6 +147,7 @@ bot.command('edit', async (ctx) => {
     reply_markup: new InlineKeyboard()
       .text(ctx.t('bot-entry-yes', { icon: ICONS.approve }), 'edit_event')
       .text(ctx.t('bot-entry-no', { icon: ICONS.reject }), 'cancel_edit'),
+    link_preview_options: disableLinkPreview,
   });
 });
 
@@ -177,6 +156,7 @@ bot.command('delete', async (ctx) => {
     reply_markup: new InlineKeyboard()
       .text(ctx.t('bot-entry-yes', { icon: ICONS.approve }), 'start_delete')
       .text(ctx.t('bot-entry-no', { icon: ICONS.reject }), 'cancel_delete'),
+    link_preview_options: disableLinkPreview,
   });
 });
 
@@ -218,39 +198,19 @@ bot.command('support', async (ctx) => {
     message += '\n' + ctx.t('msg-support-no-contact', { icon: noContactIcon });
   }
 
-  await ctx.replyWithMarkdownV2(message);
+  await ctx.replyWithMarkdownV2(message, {
+    link_preview_options: disableLinkPreview,
+  });
 });
 
 bot.command('rules', async (ctx) => {
   const icon = ICONS.rules || '📜';
   const notice = ctx.t('msg-rules-notice', { icon });
 
-  await ctx.replyWithMarkdownV2(notice);
+  await ctx.replyWithMarkdownV2(notice, {
+    link_preview_options: disableLinkPreview,
+  });
 });
-
-// bot.callbackQuery(/^set_lang_(en|de)$/, async (ctx) => {
-//   const newLocale = ctx.match[1];
-//   await ctx.i18n.setLocale(newLocale);
-//   ctx.session.locale = newLocale;
-
-//   await ctx.answerCallbackQuery(
-//     ctx.t('bot-entry-language-set', {
-//       locale:
-//         newLocale === 'en'
-//           ? ctx.t('bot-entry-language-english')
-//           : ctx.t('bot-entry-language-german'),
-//     }),
-//   );
-
-//   await ctx.replyWithMarkdownV2(
-//     ctx.t('bot-entry-language-set', {
-//       locale:
-//         newLocale === 'en'
-//           ? ctx.t('bot-entry-language-english')
-//           : ctx.t('bot-entry-language-german'),
-//     }),
-//   );
-// });
 
 bot.callbackQuery('submit_event', async (ctx) => {
   await ctx.answerCallbackQuery();
@@ -261,6 +221,7 @@ bot.callbackQuery('cancel_submit', async (ctx) => {
   await ctx.answerCallbackQuery();
   await ctx.replyWithMarkdownV2(
     ctx.t('bot-entry-submit-cancelled', { icon: ICONS.reject }),
+    { link_preview_options: disableLinkPreview },
   );
 });
 
@@ -278,6 +239,7 @@ bot.callbackQuery('cancel_edit', async (ctx) => {
   await ctx.answerCallbackQuery();
   await ctx.replyWithMarkdownV2(
     ctx.t('bot-entry-edit-cancelled', { icon: ICONS.reject }),
+    { link_preview_options: disableLinkPreview },
   );
 });
 
@@ -290,12 +252,15 @@ bot.callbackQuery('cancel_delete', async (ctx) => {
   await ctx.answerCallbackQuery();
   await ctx.replyWithMarkdownV2(
     ctx.t('bot-entry-delete-cancelled', { icon: ICONS.reject }),
+    { link_preview_options: disableLinkPreview },
   );
 });
 
 bot.callbackQuery('cancel_conversation', async (ctx) => {
   await ctx.answerCallbackQuery();
-  await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-cancelled'));
+  await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-cancelled'), {
+    link_preview_options: disableLinkPreview,
+  });
   console.log('Conversation cancelled');
   return;
 });
@@ -309,17 +274,6 @@ bot.callbackQuery(/reject_(edit_)?(.+)/, async (ctx) => {
   const eventId = ctx.match[2];
   await handleEventRejection(eventId, ctx);
 });
-
-// Debugging
-// Chat-ID
-// bot.on('message', (ctx) => {
-//   console.log('Chat-ID:', ctx.chat.id);
-// });
-
-// Channel Post
-// bot.on('channel_post', (ctx) => {
-//   console.log('Channel Post Chat-ID:', ctx.chat.id);
-// });
 
 export function startBot() {
   run(bot, {

--- a/src/conversations/deleteEventConversation.ts
+++ b/src/conversations/deleteEventConversation.ts
@@ -9,6 +9,10 @@ import { MyContext } from '../types/context';
 import { ICONS } from '../utils/iconUtils';
 import { formatEvent } from '../utils/eventMessageFormatter';
 
+const disableLinkPreview = {
+  is_disabled: true,
+};
+
 export async function deleteEventConversation(
   conversation: Conversation<MyContext>,
   ctx: MyContext,
@@ -17,7 +21,9 @@ export async function deleteEventConversation(
     const userId = ctx.from?.id;
 
     if (!userId) {
-      await ctx.replyWithMarkdownV2(ctx.t('msg-delete-event-user-not-found'));
+      await ctx.replyWithMarkdownV2(ctx.t('msg-delete-event-user-not-found'), {
+        link_preview_options: disableLinkPreview,
+      });
       return;
     }
 
@@ -26,28 +32,33 @@ export async function deleteEventConversation(
     if (events.length === 0) {
       await ctx.replyWithMarkdownV2(
         ctx.t('msg-delete-event-no-approved-events-found'),
+        { link_preview_options: disableLinkPreview },
       );
       return;
     }
 
     const eventToDelete = await selectEventToDelete(conversation, ctx, events);
     if (!eventToDelete) {
-      await ctx.replyWithMarkdownV2(ctx.t('msg-delete-event-cancelled'));
+      await ctx.replyWithMarkdownV2(ctx.t('msg-delete-event-cancelled'), {
+        link_preview_options: disableLinkPreview,
+      });
       return;
     }
 
     const confirmed = await confirmDeletion(conversation, ctx, eventToDelete);
     if (!confirmed) {
-      await ctx.replyWithMarkdownV2(ctx.t('msg-delete-event-cancelled'));
+      await ctx.replyWithMarkdownV2(ctx.t('msg-delete-event-cancelled'), {
+        link_preview_options: disableLinkPreview,
+      });
       return;
     }
 
-    // Event löschen
     await handleEventDeletion(eventToDelete.id, ctx);
   } catch (error) {
     console.error('Error during delete event conversation:', error);
     await ctx.replyWithMarkdownV2(
       ctx.t('msg-delete-event-error', { icon: ICONS.reject }),
+      { link_preview_options: disableLinkPreview },
     );
   }
 }
@@ -73,6 +84,7 @@ async function selectEventToDelete(
 
   await ctx.replyWithMarkdownV2(ctx.t('msg-delete-event-select-event'), {
     reply_markup: keyboard,
+    link_preview_options: disableLinkPreview,
   });
 
   const response = await conversation.waitForCallbackQuery([
@@ -92,12 +104,15 @@ async function selectEventToDelete(
   const event = await findEventById(eventId);
 
   if (!event) {
-    await ctx.replyWithMarkdownV2(ctx.t('msg-delete-event-not-found-error'));
+    await ctx.replyWithMarkdownV2(ctx.t('msg-delete-event-not-found-error'), {
+      link_preview_options: disableLinkPreview,
+    });
     return null;
   }
 
-  // Zeige Event-Details zur Bestätigung
-  await ctx.replyWithMarkdownV2(ctx.t('msg-delete-event-selected-details'));
+  await ctx.replyWithMarkdownV2(ctx.t('msg-delete-event-selected-details'), {
+    link_preview_options: disableLinkPreview,
+  });
   const messageText = formatEvent(ctx, event, { context: 'user' });
 
   if (event.imageBase64) {
@@ -113,10 +128,16 @@ async function selectEventToDelete(
         `Error sending photo for event ID=${event.id} during deletion selection:`,
         error,
       );
-      await ctx.replyWithMarkdownV2(messageText, { parse_mode: 'MarkdownV2' }); // Fallback auf Text
+      await ctx.replyWithMarkdownV2(messageText, {
+        parse_mode: 'MarkdownV2',
+        link_preview_options: disableLinkPreview,
+      });
     }
   } else {
-    await ctx.replyWithMarkdownV2(messageText, { parse_mode: 'MarkdownV2' });
+    await ctx.replyWithMarkdownV2(messageText, {
+      parse_mode: 'MarkdownV2',
+      link_preview_options: disableLinkPreview,
+    });
   }
 
   return event;
@@ -143,6 +164,7 @@ async function confirmDeletion(
     }),
     {
       reply_markup: confirmationKeyboard,
+      link_preview_options: disableLinkPreview,
     },
   );
 

--- a/src/conversations/editEventConversation.ts
+++ b/src/conversations/editEventConversation.ts
@@ -30,6 +30,10 @@ import { escapeMarkdownV2Text } from '../utils/markdownUtils';
 
 const locale = getLocaleUtil();
 
+const disableLinkPreview = {
+  is_disabled: true,
+};
+
 export async function editEventConversation(
   conversation: Conversation<MyContext>,
   ctx: MyContext,
@@ -38,7 +42,9 @@ export async function editEventConversation(
     const userId = ctx.from?.id;
 
     if (!userId) {
-      await ctx.replyWithMarkdownV2(ctx.t('msg-edit-event-user-not-found'));
+      await ctx.replyWithMarkdownV2(ctx.t('msg-edit-event-user-not-found'), {
+        link_preview_options: disableLinkPreview,
+      });
       return;
     }
 
@@ -47,6 +53,7 @@ export async function editEventConversation(
     if (events.length === 0) {
       await ctx.replyWithMarkdownV2(
         ctx.t('msg-edit-event-no-approved-events-found'),
+        { link_preview_options: disableLinkPreview },
       );
       return;
     }
@@ -57,7 +64,10 @@ export async function editEventConversation(
     });
 
     if (availableEvents.length === 0) {
-      await ctx.replyWithMarkdownV2(ctx.t('msg-edit-event-edit-limit-reached'));
+      await ctx.replyWithMarkdownV2(
+        ctx.t('msg-edit-event-edit-limit-reached'),
+        { link_preview_options: disableLinkPreview },
+      );
       return;
     }
 
@@ -128,6 +138,7 @@ export async function editEventConversation(
     console.error('Error while editing the event:', error);
     await ctx.replyWithMarkdownV2(
       ctx.t('msg-edit-event-error', { icon: ICONS.reject }),
+      { link_preview_options: disableLinkPreview },
     );
   }
 }
@@ -166,6 +177,7 @@ async function selectEvent(
 
   await ctx.replyWithMarkdownV2(ctx.t('msg-edit-event-select-event-to-edit'), {
     reply_markup: keyboard,
+    link_preview_options: disableLinkPreview,
   });
 
   const eventSelection = await conversation.waitForCallbackQuery(
@@ -182,16 +194,20 @@ async function selectEvent(
       ctx.t('msg-edit-event-remaining-edits', {
         remainingEdits,
       }),
+      { link_preview_options: disableLinkPreview },
     );
     if (remainingEdits <= 0) {
       await ctx.replyWithMarkdownV2(
         ctx.t('msg-edit-event-remaining-edits-reached'),
+        { link_preview_options: disableLinkPreview },
       );
       return null;
     }
   }
 
-  await ctx.replyWithMarkdownV2(ctx.t('msg-edit-event-event-data'));
+  await ctx.replyWithMarkdownV2(ctx.t('msg-edit-event-event-data'), {
+    link_preview_options: disableLinkPreview,
+  });
 
   const messageText = formatEvent(ctx, event, {
     context: 'user',
@@ -209,10 +225,13 @@ async function selectEvent(
       console.error(`Error while sending image ID=${event.id}:`, error);
       await ctx.replyWithMarkdownV2(
         ctx.t('msg-edit-event-summary-error-by-sending-image'),
+        { link_preview_options: disableLinkPreview },
       );
     }
   } else {
-    await ctx.replyWithMarkdownV2(messageText);
+    await ctx.replyWithMarkdownV2(messageText, {
+      link_preview_options: disableLinkPreview,
+    });
   }
 
   return event;
@@ -235,18 +254,23 @@ async function collectEventTitle(
             ctx.t('msg-edit-event-btn-cancel', { icon: ICONS.reject }),
             'cancel_conversation',
           ),
+        link_preview_options: disableLinkPreview,
       });
       const response = await conversation.wait();
 
       if (response.callbackQuery?.data === 'cancel_conversation') {
         await response.answerCallbackQuery();
-        await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-cancelled'));
+        await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-cancelled'), {
+          link_preview_options: disableLinkPreview,
+        });
         return false;
       }
 
       if (response.callbackQuery?.data === 'skip_question') {
         await response.answerCallbackQuery();
-        await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-skipped'));
+        await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-skipped'), {
+          link_preview_options: disableLinkPreview,
+        });
         return true;
       }
 
@@ -256,6 +280,7 @@ async function collectEventTitle(
             ctx.t('msg-edit-event-new-title-too-long', {
               icon: ICONS.reject,
             }),
+            { link_preview_options: disableLinkPreview },
           );
           continue;
         } else {
@@ -267,6 +292,7 @@ async function collectEventTitle(
       console.error('Error while collecting the title:', error);
       await ctx.replyWithMarkdownV2(
         ctx.t('msg-edit-event-title-error', { icon: ICONS.reject }),
+        { link_preview_options: disableLinkPreview },
       );
     }
   }
@@ -290,18 +316,23 @@ async function collectEventDescription(
             ctx.t('msg-edit-event-btn-cancel', { icon: ICONS.reject }),
             'cancel_conversation',
           ),
+        link_preview_options: disableLinkPreview,
       });
       const response = await conversation.wait();
 
       if (response.callbackQuery?.data === 'cancel_conversation') {
         await response.answerCallbackQuery();
-        await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-cancelled'));
+        await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-cancelled'), {
+          link_preview_options: disableLinkPreview,
+        });
         return false;
       }
 
       if (response.callbackQuery?.data === 'skip_question') {
         await response.answerCallbackQuery();
-        await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-skipped'));
+        await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-skipped'), {
+          link_preview_options: disableLinkPreview,
+        });
         return true;
       }
 
@@ -311,6 +342,7 @@ async function collectEventDescription(
             ctx.t('msg-edit-event-new-description-too-long', {
               icon: ICONS.reject,
             }),
+            { link_preview_options: disableLinkPreview },
           );
           continue;
         } else {
@@ -322,6 +354,7 @@ async function collectEventDescription(
       console.error('Error while collecting the description:', error);
       await ctx.replyWithMarkdownV2(
         ctx.t('msg-edit-event-description-error', { icon: ICONS.reject }),
+        { link_preview_options: disableLinkPreview },
       );
     }
   }
@@ -345,18 +378,23 @@ async function collectEventLocation(
             ctx.t('msg-edit-event-btn-cancel', { icon: ICONS.reject }),
             'cancel_conversation',
           ),
+        link_preview_options: disableLinkPreview,
       });
       const response = await conversation.wait();
 
       if (response.callbackQuery?.data === 'cancel_conversation') {
         await response.answerCallbackQuery();
-        await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-cancelled'));
+        await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-cancelled'), {
+          link_preview_options: disableLinkPreview,
+        });
         return false;
       }
 
       if (response.callbackQuery?.data === 'skip_question') {
         await response.answerCallbackQuery();
-        await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-skipped'));
+        await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-skipped'), {
+          link_preview_options: disableLinkPreview,
+        });
         return true;
       }
 
@@ -366,6 +404,7 @@ async function collectEventLocation(
             ctx.t('msg-edit-event-new-location-to-short', {
               icon: ICONS.reject,
             }),
+            { link_preview_options: disableLinkPreview },
           );
           continue;
         } else {
@@ -377,6 +416,7 @@ async function collectEventLocation(
       console.error('Error while collecting the location:', error);
       await ctx.replyWithMarkdownV2(
         ctx.t('msg-edit-event-location-error', { icon: ICONS.reject }),
+        { link_preview_options: disableLinkPreview },
       );
     }
   }
@@ -410,19 +450,24 @@ async function collectEventDates(
                 ctx.t('msg-edit-event-btn-cancel', { icon: ICONS.reject }),
                 'cancel_conversation',
               ),
+            link_preview_options: disableLinkPreview,
           },
         );
         const entryResponse = await conversation.wait();
 
         if (entryResponse.callbackQuery?.data === 'cancel_conversation') {
           await entryResponse.answerCallbackQuery();
-          await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-cancelled'));
+          await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-cancelled'), {
+            link_preview_options: disableLinkPreview,
+          });
           return false;
         }
 
         if (entryResponse.callbackQuery?.data === 'skip_question') {
           await entryResponse.answerCallbackQuery();
-          await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-skipped'));
+          await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-skipped'), {
+            link_preview_options: disableLinkPreview,
+          });
           return true;
         }
 
@@ -440,6 +485,7 @@ async function collectEventDates(
                 icon: ICONS.reject,
                 date: escapeMarkdownV2Text(getDateFormat()),
               }),
+              { link_preview_options: disableLinkPreview },
             );
             continue;
           }
@@ -449,6 +495,7 @@ async function collectEventDates(
               ctx.t('msg-edit-event-new-entry-date-future', {
                 icon: ICONS.reject,
               }),
+              { link_preview_options: disableLinkPreview },
             );
             continue;
           }
@@ -477,19 +524,24 @@ async function collectEventDates(
                 ctx.t('msg-edit-event-btn-cancel', { icon: ICONS.reject }),
                 'cancel_conversation',
               ),
+            link_preview_options: disableLinkPreview,
           },
         );
         const startResponse = await conversation.wait();
 
         if (startResponse.callbackQuery?.data === 'cancel_conversation') {
           await startResponse.answerCallbackQuery();
-          await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-cancelled'));
+          await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-cancelled'), {
+            link_preview_options: disableLinkPreview,
+          });
           return false;
         }
 
         if (startResponse.callbackQuery?.data === 'skip_question') {
           await startResponse.answerCallbackQuery();
-          await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-skipped'));
+          await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-skipped'), {
+            link_preview_options: disableLinkPreview,
+          });
           return true;
         }
 
@@ -507,6 +559,7 @@ async function collectEventDates(
                 icon: ICONS.reject,
                 date: escapeMarkdownV2Text(getDateFormat()),
               }),
+              { link_preview_options: disableLinkPreview },
             );
             continue;
           }
@@ -516,6 +569,7 @@ async function collectEventDates(
               ctx.t('msg-edit-event-new-start-date-future', {
                 icon: ICONS.reject,
               }),
+              { link_preview_options: disableLinkPreview },
             );
             continue;
           }
@@ -530,6 +584,7 @@ async function collectEventDates(
               ctx.t('msg-edit-event-new-start-after-entry', {
                 icon: ICONS.reject,
               }),
+              { link_preview_options: disableLinkPreview },
             );
             continue;
           }
@@ -553,19 +608,24 @@ async function collectEventDates(
                 ctx.t('msg-edit-event-btn-cancel', { icon: ICONS.reject }),
                 'cancel_conversation',
               ),
+            link_preview_options: disableLinkPreview,
           },
         );
         const endResponse = await conversation.wait();
 
         if (endResponse.callbackQuery?.data === 'cancel_conversation') {
           await endResponse.answerCallbackQuery();
-          await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-cancelled'));
+          await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-cancelled'), {
+            link_preview_options: disableLinkPreview,
+          });
           return false;
         }
 
         if (endResponse.callbackQuery?.data === 'skip_question') {
           await endResponse.answerCallbackQuery();
-          await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-skipped'));
+          await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-skipped'), {
+            link_preview_options: disableLinkPreview,
+          });
           return true;
         }
 
@@ -583,6 +643,7 @@ async function collectEventDates(
                 icon: ICONS.reject,
                 date: escapeMarkdownV2Text(getDateFormat()),
               }),
+              { link_preview_options: disableLinkPreview },
             );
             continue;
           }
@@ -592,6 +653,7 @@ async function collectEventDates(
               ctx.t('msg-edit-event-new-end-date-future', {
                 icon: ICONS.reject,
               }),
+              { link_preview_options: disableLinkPreview },
             );
             continue;
           }
@@ -603,6 +665,7 @@ async function collectEventDates(
               ctx.t('msg-edit-event-new-end-after-start', {
                 icon: ICONS.reject,
               }),
+              { link_preview_options: disableLinkPreview },
             );
             continue;
           }
@@ -650,6 +713,7 @@ async function collectEventDates(
               }),
               'dates_reset',
             ),
+          link_preview_options: disableLinkPreview,
         },
       );
 
@@ -675,6 +739,7 @@ async function collectEventDates(
       console.error('Error while collecting date information:', error);
       await ctx.replyWithMarkdownV2(
         ctx.t('msg-edit-event-dates-error', { icon: ICONS.reject }),
+        { link_preview_options: disableLinkPreview },
       );
     }
   }
@@ -794,6 +859,7 @@ async function collectEventCategories(
         ],
       ],
     },
+    link_preview_options: disableLinkPreview,
   });
 
   while (!categorySelectionComplete) {
@@ -835,6 +901,7 @@ async function collectEventCategories(
         ctx.t('msg-edit-event-output-selected-cats', {
           selectedCategories: selectedCategories.join(', '),
         }),
+        { link_preview_options: disableLinkPreview },
       );
     }
   }
@@ -856,18 +923,23 @@ async function collectEventLinks(
         ctx.t('msg-edit-event-btn-cancel', { icon: ICONS.reject }),
         'cancel_conversation',
       ),
+    link_preview_options: disableLinkPreview,
   });
   const linksResponse = await conversation.wait();
 
   if (linksResponse.callbackQuery?.data === 'cancel_conversation') {
     await linksResponse.answerCallbackQuery();
-    await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-cancelled'));
+    await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-cancelled'), {
+      link_preview_options: disableLinkPreview,
+    });
     return false;
   }
 
   if (linksResponse.callbackQuery?.data === 'skip_question') {
     await linksResponse.answerCallbackQuery();
-    await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-skipped'));
+    await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-skipped'), {
+      link_preview_options: disableLinkPreview,
+    });
     return true;
   }
 
@@ -902,19 +974,24 @@ async function collectEventGroupLink(
               ctx.t('msg-edit-event-btn-cancel', { icon: ICONS.reject }),
               'cancel_conversation',
             ),
+          link_preview_options: disableLinkPreview,
         },
       );
       const response = await conversation.wait();
 
       if (response.callbackQuery?.data === 'cancel_conversation') {
         await response.answerCallbackQuery();
-        await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-cancelled'));
+        await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-cancelled'), {
+          link_preview_options: disableLinkPreview,
+        });
         return false;
       }
 
       if (response.callbackQuery?.data === 'skip_question') {
         await response.answerCallbackQuery();
-        await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-skipped'));
+        await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-skipped'), {
+          link_preview_options: disableLinkPreview,
+        });
         return true;
       }
 
@@ -926,6 +1003,7 @@ async function collectEventGroupLink(
       console.error('Error while collecting the group link:', error);
       await ctx.replyWithMarkdownV2(
         ctx.t('msg-edit-event-group-link-error', { icon: ICONS.reject }),
+        { link_preview_options: disableLinkPreview },
       );
     }
   }
@@ -951,18 +1029,23 @@ async function collectEventImage(
             ctx.t('msg-edit-event-btn-cancel', { icon: ICONS.reject }),
             'cancel_conversation',
           ),
+        link_preview_options: disableLinkPreview,
       });
       const imageResponse = await conversation.wait();
 
       if (imageResponse.callbackQuery?.data === 'cancel_conversation') {
         await imageResponse.answerCallbackQuery();
-        await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-cancelled'));
+        await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-cancelled'), {
+          link_preview_options: disableLinkPreview,
+        });
         return false;
       }
 
       if (imageResponse.callbackQuery?.data === 'skip_question') {
         await imageResponse.answerCallbackQuery();
-        await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-skipped'));
+        await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-skipped'), {
+          link_preview_options: disableLinkPreview,
+        });
         return true;
       }
 
@@ -978,6 +1061,7 @@ async function collectEventImage(
         if (!response.ok) {
           await ctx.replyWithMarkdownV2(
             ctx.t('msg-edit-event-image-download-error'),
+            { link_preview_options: disableLinkPreview },
           );
           continue;
         }
@@ -992,12 +1076,14 @@ async function collectEventImage(
       } else {
         await ctx.replyWithMarkdownV2(
           ctx.t('msg-edit-event-image-invalid-input'),
+          { link_preview_options: disableLinkPreview },
         );
       }
     } catch (error) {
       console.error('Error while collecting the image:', error);
       await ctx.replyWithMarkdownV2(
         ctx.t('msg-edit-event-image-error', { icon: ICONS.reject }),
+        { link_preview_options: disableLinkPreview },
       );
     }
   }
@@ -1010,26 +1096,9 @@ async function summarizeAndSaveEvent(
   originalEvent: Event,
   updatedEventData: Partial<Event>,
 ) {
-  await ctx.replyWithMarkdownV2(ctx.t('msg-edit-event-changes'));
-
-  // if (originalEvent.imageBase64) {
-  //   try {
-  //     const imageBuffer = Buffer.from(originalEvent.imageBase64, 'base64');
-  //     const stream = Readable.from(imageBuffer);
-  //     await ctx.replyWithPhoto(new InputFile(stream), {
-  //       caption: ctx.t( 'msg-edit-event-summary-event-image'),
-  //
-  //     });
-  //   } catch (error) {
-  //     console.error(
-  //       `Error by sending image for Event ID=${originalEvent.id}:`,
-  //       error,
-  //     );
-  //     await ctx.replyWithMarkdownV2(
-  //       ctx.t( 'msg-edit-event-summary-error-by-sending-image'),
-  //     );
-  //   }
-  // }
+  await ctx.replyWithMarkdownV2(ctx.t('msg-edit-event-changes'), {
+    link_preview_options: disableLinkPreview,
+  });
 
   const updatedMessageText = formatEvent(ctx, updatedEventData as Event, {
     context: 'user',
@@ -1050,10 +1119,13 @@ async function summarizeAndSaveEvent(
       );
       await ctx.replyWithMarkdownV2(
         ctx.t('msg-edit-event-summary-error-by-sending-image'),
+        { link_preview_options: disableLinkPreview },
       );
     }
   } else {
-    await ctx.replyWithMarkdownV2(updatedMessageText);
+    await ctx.replyWithMarkdownV2(updatedMessageText, {
+      link_preview_options: disableLinkPreview,
+    });
   }
 
   await ctx.replyWithMarkdownV2(ctx.t('msg-edit-event-summary-save-changes'), {
@@ -1066,6 +1138,7 @@ async function summarizeAndSaveEvent(
         ctx.t('msg-edit-event-field-no', { icon: ICONS.reject }),
         'discard_changes',
       ),
+    link_preview_options: disableLinkPreview,
   });
 
   const saveChanges = await conversation.waitForCallbackQuery([
@@ -1085,13 +1158,19 @@ async function summarizeAndSaveEvent(
 
     if (getEventsRequireApproval()) {
       await sendEventToAdmins(ctx, updatedEventFromDb, true);
-      await ctx.replyWithMarkdownV2(ctx.t('msg-edit-event-save-review'));
+      await ctx.replyWithMarkdownV2(ctx.t('msg-edit-event-save-review'), {
+        link_preview_options: disableLinkPreview,
+      });
     } else {
       await publishEvent(ctx, updatedEventFromDb);
-      await ctx.replyWithMarkdownV2(ctx.t('msg-edit-event-save'));
+      await ctx.replyWithMarkdownV2(ctx.t('msg-edit-event-save'), {
+        link_preview_options: disableLinkPreview,
+      });
     }
   } else {
-    await ctx.replyWithMarkdownV2(ctx.t('msg-edit-event-changes-reject'));
+    await ctx.replyWithMarkdownV2(ctx.t('msg-edit-event-changes-reject'), {
+      link_preview_options: disableLinkPreview,
+    });
   }
 }
 
@@ -1120,6 +1199,7 @@ async function askAndCollectField(
           ctx.t('msg-edit-event-field-no', { icon: ICONS.reject }),
           `skip_${fieldName}`,
         ),
+      link_preview_options: disableLinkPreview,
     },
   );
 

--- a/src/conversations/rejectEventConversation.ts
+++ b/src/conversations/rejectEventConversation.ts
@@ -6,6 +6,10 @@ import { getAdminChatId } from '../constants/constants';
 import { escapeMarkdownV2Text } from '../utils/markdownUtils';
 import { ICONS } from '../utils/iconUtils';
 
+const disableLinkPreview = {
+  is_disabled: true,
+};
+
 export async function rejectEventConversation(
   conversation: Conversation<MyContext>,
   ctx: MyContext,
@@ -14,17 +18,24 @@ export async function rejectEventConversation(
     const eventId = ctx.session.eventId;
 
     if (!eventId) {
-      await ctx.replyWithMarkdownV2(ctx.t('msg-reject-event-no-eventid-found'));
+      await ctx.replyWithMarkdownV2(
+        ctx.t('msg-reject-event-no-eventid-found'),
+        { link_preview_options: disableLinkPreview },
+      );
       return;
     }
 
     const event = await findEventById(eventId);
     if (!event) {
-      await ctx.replyWithMarkdownV2(ctx.t('msg-reject-event-not-found'));
+      await ctx.replyWithMarkdownV2(ctx.t('msg-reject-event-not-found'), {
+        link_preview_options: disableLinkPreview,
+      });
       return;
     }
 
-    await ctx.replyWithMarkdownV2(ctx.t('msg-reject-event-rejection-reason'));
+    await ctx.replyWithMarkdownV2(ctx.t('msg-reject-event-rejection-reason'), {
+      link_preview_options: disableLinkPreview,
+    });
 
     const reasonResponse = await conversation.waitFor('message:text');
     const rejectionReason = reasonResponse.message.text;
@@ -39,6 +50,7 @@ export async function rejectEventConversation(
           eventTitle: escapeMarkdownV2Text(event.title),
           rejectionReason: escapeMarkdownV2Text(rejectionReason),
         }),
+        { link_preview_options: disableLinkPreview },
       );
 
       const messageId = ctx.callbackQuery?.message?.message_id;
@@ -67,6 +79,7 @@ export async function rejectEventConversation(
         }),
         {
           reply_to_message_id: messageId,
+          link_preview_options: disableLinkPreview,
         },
       );
     } catch (error) {
@@ -78,6 +91,7 @@ export async function rejectEventConversation(
     console.error('Error rejecting the event:', error);
     await ctx.replyWithMarkdownV2(
       ctx.t('msg-reject-event-error', { icon: ICONS.reject }),
+      { link_preview_options: disableLinkPreview },
     );
   }
 }

--- a/src/conversations/searchEventConversation.ts
+++ b/src/conversations/searchEventConversation.ts
@@ -13,6 +13,10 @@ import { escapeMarkdownV2Text } from '../utils/markdownUtils';
 
 const locale = getLocaleUtil();
 
+const disableLinkPreview = {
+  is_disabled: true,
+};
+
 export async function searchEventConversation(
   conversation: Conversation<MyContext>,
   ctx: MyContext,
@@ -26,6 +30,7 @@ export async function searchEventConversation(
     console.error('Error searching for events:', error);
     await ctx.replyWithMarkdownV2(
       ctx.t('msg-search-event-error', { icon: ICONS.reject }),
+      { link_preview_options: disableLinkPreview },
     );
   }
 }
@@ -60,6 +65,7 @@ async function showSearchOptions(
       ctx.t('msg-search-event-title', { icon: ICONS.search }),
       {
         reply_markup: searchKeyboard,
+        link_preview_options: disableLinkPreview,
       },
     );
 
@@ -78,6 +84,7 @@ async function showSearchOptions(
     if (response.callbackQuery.data === 'search_exit') {
       await ctx.replyWithMarkdownV2(
         ctx.t('msg-search-event-exit', { icon: ICONS.reject }),
+        { link_preview_options: disableLinkPreview },
       );
       return null;
     }
@@ -87,6 +94,7 @@ async function showSearchOptions(
     console.error('Error displaying search options:', error);
     await ctx.replyWithMarkdownV2(
       ctx.t('msg-search-event-options-error', { icon: ICONS.reject }),
+      { link_preview_options: disableLinkPreview },
     );
     return null;
   }
@@ -111,6 +119,7 @@ async function handleSearchChoice(
       default:
         await ctx.replyWithMarkdownV2(
           ctx.t('msg-search-event-invalid-choice', { icon: ICONS.reject }),
+          { link_preview_options: disableLinkPreview },
         );
         break;
     }
@@ -118,6 +127,7 @@ async function handleSearchChoice(
     console.error('Error processing search choice:', error);
     await ctx.replyWithMarkdownV2(
       ctx.t('msg-search-event-choice-error', { icon: ICONS.reject }),
+      { link_preview_options: disableLinkPreview },
     );
   }
 }
@@ -136,6 +146,7 @@ async function handleTodaySearch(ctx: MyContext) {
     console.error('Error searching for todays events:', error);
     await ctx.replyWithMarkdownV2(
       ctx.t('msg-search-event-today-error', { icon: ICONS.reject }),
+      { link_preview_options: disableLinkPreview },
     );
   }
 }
@@ -154,6 +165,7 @@ async function handleTomorrowSearch(ctx: MyContext) {
     console.error("Error searching for tomorrow's events:", error);
     await ctx.replyWithMarkdownV2(
       ctx.t('msg-search-event-tomorrow-error', { icon: ICONS.reject }),
+      { link_preview_options: disableLinkPreview },
     );
   }
 }
@@ -179,6 +191,7 @@ async function handleSpecificDateSearch(
       }),
       {
         reply_markup: dateKeyboard,
+        link_preview_options: disableLinkPreview,
       },
     );
 
@@ -190,6 +203,7 @@ async function handleSpecificDateSearch(
     if (dateResponse.callbackQuery?.data === 'cancel_date_search') {
       await ctx.replyWithMarkdownV2(
         ctx.t('msg-search-event-cancel', { icon: ICONS.reject }),
+        { link_preview_options: disableLinkPreview },
       );
       return;
     }
@@ -211,6 +225,7 @@ async function handleSpecificDateSearch(
           icon: ICONS.reject,
           format: escapeMarkdownV2Text(getDateOnlyFormat()),
         }),
+        { link_preview_options: disableLinkPreview },
       );
       continue;
     }

--- a/src/conversations/submitEventConversation.ts
+++ b/src/conversations/submitEventConversation.ts
@@ -22,6 +22,10 @@ import { escapeMarkdownV2Text } from '../utils/markdownUtils';
 
 const locale = getLocaleUtil();
 
+const disableLinkPreview = {
+  is_disabled: true,
+};
+
 export async function submitEventConversation(
   conversation: Conversation<MyContext>,
   ctx: MyContext,
@@ -119,6 +123,7 @@ async function collectEventTitle(
         ctx.t('msg-submit-event-title', { icon: ICONS.event }),
         {
           reply_markup: createCancelKeyboard(ctx),
+          link_preview_options: disableLinkPreview,
         },
       );
 
@@ -126,7 +131,12 @@ async function collectEventTitle(
 
       if (response.callbackQuery?.data === 'cancel_conversation') {
         await response.answerCallbackQuery();
-        await response.replyWithMarkdownV2(ctx.t('msg-conversation-cancelled'));
+        await response.replyWithMarkdownV2(
+          ctx.t('msg-conversation-cancelled'),
+          {
+            link_preview_options: disableLinkPreview,
+          },
+        );
         return false;
       }
 
@@ -136,6 +146,9 @@ async function collectEventTitle(
             ctx.t('msg-submit-event-title-too-long', {
               icon: ICONS.reject,
             }),
+            {
+              link_preview_options: disableLinkPreview,
+            },
           );
           continue;
         }
@@ -146,6 +159,9 @@ async function collectEventTitle(
       console.error('Error capturing the title:', error);
       await ctx.replyWithMarkdownV2(
         ctx.t('msg-submit-event-title-error', { icon: ICONS.reject }),
+        {
+          link_preview_options: disableLinkPreview,
+        },
       );
     }
   }
@@ -162,6 +178,7 @@ async function collectEventDescription(
         ctx.t('msg-submit-event-description', { icon: ICONS.pensil }),
         {
           reply_markup: createCancelKeyboard(ctx),
+          link_preview_options: disableLinkPreview,
         },
       );
 
@@ -169,7 +186,12 @@ async function collectEventDescription(
 
       if (response.callbackQuery?.data === 'cancel_conversation') {
         await response.answerCallbackQuery();
-        await response.replyWithMarkdownV2(ctx.t('msg-conversation-cancelled'));
+        await response.replyWithMarkdownV2(
+          ctx.t('msg-conversation-cancelled'),
+          {
+            link_preview_options: disableLinkPreview,
+          },
+        );
         return false;
       }
 
@@ -179,6 +201,9 @@ async function collectEventDescription(
             ctx.t('msg-submit-event-description-too-long', {
               icon: ICONS.reject,
             }),
+            {
+              link_preview_options: disableLinkPreview,
+            },
           );
           continue;
         }
@@ -189,6 +214,9 @@ async function collectEventDescription(
       console.error('Error capturing the description:', error);
       await ctx.replyWithMarkdownV2(
         ctx.t('msg-submit-event-description-error', { icon: ICONS.reject }),
+        {
+          link_preview_options: disableLinkPreview,
+        },
       );
     }
   }
@@ -205,6 +233,7 @@ async function collectEventLocation(
         ctx.t('msg-submit-event-location', { icon: ICONS.pensil }),
         {
           reply_markup: createCancelKeyboard(ctx),
+          link_preview_options: disableLinkPreview,
         },
       );
 
@@ -212,7 +241,12 @@ async function collectEventLocation(
 
       if (response.callbackQuery?.data === 'cancel_conversation') {
         await response.answerCallbackQuery();
-        await response.replyWithMarkdownV2(ctx.t('msg-conversation-cancelled'));
+        await response.replyWithMarkdownV2(
+          ctx.t('msg-conversation-cancelled'),
+          {
+            link_preview_options: disableLinkPreview,
+          },
+        );
         return false;
       }
 
@@ -223,6 +257,9 @@ async function collectEventLocation(
             ctx.t('msg-submit-event-location-invalid', {
               icon: ICONS.reject,
             }),
+            {
+              link_preview_options: disableLinkPreview,
+            },
           );
           continue;
         }
@@ -233,6 +270,9 @@ async function collectEventLocation(
       console.error('Error capturing the location:', error);
       await ctx.replyWithMarkdownV2(
         ctx.t('msg-submit-event-location-error', { icon: ICONS.reject }),
+        {
+          link_preview_options: disableLinkPreview,
+        },
       );
     }
   }
@@ -258,6 +298,7 @@ async function collectEventDates(
           }),
           {
             reply_markup: createCancelKeyboard(ctx),
+            link_preview_options: disableLinkPreview,
           },
         );
         const entryResponse = await conversation.wait();
@@ -266,6 +307,9 @@ async function collectEventDates(
           await entryResponse.answerCallbackQuery();
           await entryResponse.replyWithMarkdownV2(
             ctx.t('msg-conversation-cancelled'),
+            {
+              link_preview_options: disableLinkPreview,
+            },
           );
           return false;
         }
@@ -285,6 +329,9 @@ async function collectEventDates(
               icon: ICONS.reject,
               date: escapeMarkdownV2Text(getDateFormat()),
             }),
+            {
+              link_preview_options: disableLinkPreview,
+            },
           );
           continue;
         }
@@ -292,6 +339,9 @@ async function collectEventDates(
         if (parsedEntryDateInTimeZone < new Date()) {
           await ctx.replyWithMarkdownV2(
             ctx.t('msg-submit-event-entry-date-future', { icon: ICONS.reject }),
+            {
+              link_preview_options: disableLinkPreview,
+            },
           );
           continue;
         }
@@ -312,6 +362,7 @@ async function collectEventDates(
           }),
           {
             reply_markup: createCancelKeyboard(ctx),
+            link_preview_options: disableLinkPreview,
           },
         );
         const startResponse = await conversation.wait();
@@ -320,6 +371,9 @@ async function collectEventDates(
           await startResponse.answerCallbackQuery();
           await startResponse.replyWithMarkdownV2(
             ctx.t('msg-conversation-cancelled'),
+            {
+              link_preview_options: disableLinkPreview,
+            },
           );
           return false;
         }
@@ -339,6 +393,9 @@ async function collectEventDates(
               icon: ICONS.reject,
               date: escapeMarkdownV2Text(getDateFormat()),
             }),
+            {
+              link_preview_options: disableLinkPreview,
+            },
           );
           continue;
         }
@@ -346,6 +403,9 @@ async function collectEventDates(
         if (parsedStartDateInTimeZone < new Date()) {
           await ctx.replyWithMarkdownV2(
             ctx.t('msg-submit-event-start-date-future', { icon: ICONS.reject }),
+            {
+              link_preview_options: disableLinkPreview,
+            },
           );
           continue;
         }
@@ -360,6 +420,9 @@ async function collectEventDates(
             ctx.t('msg-submit-event-start-date-before-entry', {
               icon: ICONS.reject,
             }),
+            {
+              link_preview_options: disableLinkPreview,
+            },
           );
           parsedStartDate = null;
           continue;
@@ -376,6 +439,7 @@ async function collectEventDates(
           }),
           {
             reply_markup: createCancelKeyboard(ctx),
+            link_preview_options: disableLinkPreview,
           },
         );
 
@@ -385,6 +449,9 @@ async function collectEventDates(
           await endResponse.answerCallbackQuery();
           await endResponse.replyWithMarkdownV2(
             ctx.t('msg-conversation-cancelled'),
+            {
+              link_preview_options: disableLinkPreview,
+            },
           );
           return false;
         }
@@ -404,6 +471,9 @@ async function collectEventDates(
               icon: ICONS.reject,
               date: escapeMarkdownV2Text(getDateFormat()),
             }),
+            {
+              link_preview_options: disableLinkPreview,
+            },
           );
           continue;
         }
@@ -411,6 +481,9 @@ async function collectEventDates(
         if (parsedEndDateInTimeZone < new Date()) {
           await ctx.replyWithMarkdownV2(
             ctx.t('msg-submit-event-end-date-future', { icon: ICONS.reject }),
+            {
+              link_preview_options: disableLinkPreview,
+            },
           );
           continue;
         }
@@ -422,6 +495,9 @@ async function collectEventDates(
             ctx.t('msg-submit-event-end-date-before-start', {
               icon: ICONS.reject,
             }),
+            {
+              link_preview_options: disableLinkPreview,
+            },
           );
           parsedEndDate = null;
           continue;
@@ -476,6 +552,7 @@ async function collectEventDates(
               ],
             ],
           },
+          link_preview_options: disableLinkPreview,
         },
       );
 
@@ -501,6 +578,9 @@ async function collectEventDates(
       console.error('Error capturing the dates:', error);
       await ctx.replyWithMarkdownV2(
         ctx.t('msg-submit-event-date-error', { icon: ICONS.reject }),
+        {
+          link_preview_options: disableLinkPreview,
+        },
       );
     }
   }
@@ -631,6 +711,7 @@ async function collectEventCategories(
                 ],
               ],
             },
+            link_preview_options: disableLinkPreview,
           },
         );
       }
@@ -641,7 +722,9 @@ async function collectEventCategories(
 
       if (response.callbackQuery.data === 'cancel_conversation') {
         await response.answerCallbackQuery();
-        await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-cancelled'));
+        await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-cancelled'), {
+          link_preview_options: disableLinkPreview,
+        });
         return false;
       }
 
@@ -666,6 +749,9 @@ async function collectEventCategories(
         );
         await ctx.replyWithMarkdownV2(
           ctx.t('msg-submit-event-category-reset', { icon: ICONS.reset }),
+          {
+            link_preview_options: disableLinkPreview,
+          },
         );
       } else {
         if (!selectedCategories.includes(selection)) {
@@ -681,6 +767,9 @@ async function collectEventCategories(
                 icon: ICONS.reject,
                 max: getMaxCategories(),
               }),
+              {
+                link_preview_options: disableLinkPreview,
+              },
             );
             continue;
           }
@@ -701,12 +790,18 @@ async function collectEventCategories(
             icon: ICONS.category,
             categories: selectedCategories.join(', '),
           }),
+          {
+            link_preview_options: disableLinkPreview,
+          },
         );
       }
     } catch (error) {
       console.error('Error capturing the categories:', error);
       await ctx.replyWithMarkdownV2(
         ctx.t('msg-submit-event-category-error', { icon: ICONS.reject }),
+        {
+          link_preview_options: disableLinkPreview,
+        },
       );
     }
   }
@@ -743,6 +838,7 @@ async function collectEventLinks(
               ],
             ],
           },
+          link_preview_options: disableLinkPreview,
         },
       );
 
@@ -750,7 +846,12 @@ async function collectEventLinks(
 
       if (response.callbackQuery?.data === 'cancel_conversation') {
         await response.answerCallbackQuery();
-        await response.replyWithMarkdownV2(ctx.t('msg-conversation-cancelled'));
+        await response.replyWithMarkdownV2(
+          ctx.t('msg-conversation-cancelled'),
+          {
+            link_preview_options: disableLinkPreview,
+          },
+        );
         return false;
       } else if (response.callbackQuery?.data === 'no_links') {
         await response.answerCallbackQuery();
@@ -760,6 +861,9 @@ async function collectEventLinks(
         if (response.message.text.length > 40) {
           await ctx.replyWithMarkdownV2(
             ctx.t('msg-submit-event-link-too-long', { icon: ICONS.reject }),
+            {
+              link_preview_options: disableLinkPreview,
+            },
           );
           continue;
         }
@@ -777,12 +881,18 @@ async function collectEventLinks(
       } else {
         await ctx.replyWithMarkdownV2(
           ctx.t('msg-submit-event-links-invalid', { icon: ICONS.reject }),
+          {
+            link_preview_options: disableLinkPreview,
+          },
         );
       }
     } catch (error) {
       console.error('Error capturing the links:', error);
       await ctx.replyWithMarkdownV2(
         ctx.t('msg-submit-event-links-error', { icon: ICONS.reject }),
+        {
+          link_preview_options: disableLinkPreview,
+        },
       );
     }
   }
@@ -816,6 +926,7 @@ async function collectEventGroupLink(
               ],
             ],
           },
+          link_preview_options: disableLinkPreview,
         },
       );
 
@@ -823,7 +934,9 @@ async function collectEventGroupLink(
 
       if (response.callbackQuery?.data === 'cancel_conversation') {
         await response.answerCallbackQuery();
-        await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-cancelled'));
+        await ctx.replyWithMarkdownV2(ctx.t('msg-conversation-cancelled'), {
+          link_preview_options: disableLinkPreview,
+        });
         return false;
       } else if (response.callbackQuery?.data === 'no_group_link') {
         await response.answerCallbackQuery();
@@ -835,12 +948,18 @@ async function collectEventGroupLink(
       } else {
         await ctx.replyWithMarkdownV2(
           ctx.t('msg-submit-event-group-link-invalid', { icon: ICONS.reject }),
+          {
+            link_preview_options: disableLinkPreview,
+          },
         );
       }
     } catch (error) {
       console.error('Error capturing the group link:', error);
       await ctx.replyWithMarkdownV2(
         ctx.t('msg-submit-event-group-link-error', { icon: ICONS.reject }),
+        {
+          link_preview_options: disableLinkPreview,
+        },
       );
     }
   }
@@ -874,6 +993,7 @@ async function collectEventImage(
               ],
             ],
           },
+          link_preview_options: disableLinkPreview,
         },
       );
       const imageResponse = await conversation.wait();
@@ -882,6 +1002,9 @@ async function collectEventImage(
         await imageResponse.answerCallbackQuery();
         await imageResponse.replyWithMarkdownV2(
           ctx.t('msg-conversation-cancelled'),
+          {
+            link_preview_options: disableLinkPreview,
+          },
         );
         return false;
       } else if (imageResponse.callbackQuery?.data === 'no_image') {
@@ -900,6 +1023,9 @@ async function collectEventImage(
         if (!response.ok) {
           await ctx.replyWithMarkdownV2(
             ctx.t('msg-submit-event-image-error', { icon: ICONS.reject }),
+            {
+              link_preview_options: disableLinkPreview,
+            },
           );
           continue;
         }
@@ -911,12 +1037,18 @@ async function collectEventImage(
       } else {
         await ctx.replyWithMarkdownV2(
           ctx.t('msg-submit-event-image-invalid', { icon: ICONS.reject }),
+          {
+            link_preview_options: disableLinkPreview,
+          },
         );
       }
     } catch (error) {
       console.error('Error capturing the image:', error);
       await ctx.replyWithMarkdownV2(
         ctx.t('msg-submit-event-image-error', { icon: ICONS.reject }),
+        {
+          link_preview_options: disableLinkPreview,
+        },
       );
     }
   }
@@ -931,11 +1063,17 @@ async function summarizeAndSaveEvent(
   if (getEventsRequireApproval()) {
     await ctx.replyWithMarkdownV2(
       ctx.t('msg-submit-event-success-pending', { icon: ICONS.approve }),
+      {
+        link_preview_options: disableLinkPreview,
+      },
     );
     await sendEventToAdmins(ctx, savedEvent);
   } else {
     await ctx.replyWithMarkdownV2(
       ctx.t('msg-submit-event-success-published', { icon: ICONS.approve }),
+      {
+        link_preview_options: disableLinkPreview,
+      },
     );
     await publishEvent(ctx, savedEvent);
   }

--- a/src/services/eventService.ts
+++ b/src/services/eventService.ts
@@ -17,6 +17,10 @@ import { ICONS } from '../utils/iconUtils';
 import { escapeMarkdownV2Text } from '../utils/markdownUtils';
 import { formatEvent } from '../utils/eventMessageFormatter';
 
+const disableLinkPreview = {
+  is_disabled: true,
+};
+
 export async function notifyAdminsOfEvent(
   ctx: MyContext,
   event: Event,
@@ -67,6 +71,7 @@ export async function notifyAdminsOfEvent(
         await bot.api.sendMessage(getAdminChatId(), messageText, {
           parse_mode: 'MarkdownV2',
           reply_markup: approveKeyboard,
+          link_preview_options: disableLinkPreview,
         });
       } catch (error) {
         console.error(
@@ -153,6 +158,7 @@ export async function handleEventApproval(eventId: string, ctx: MyContext) {
 
         await bot.api.sendMessage(getAdminChatId(), message, {
           parse_mode: 'MarkdownV2',
+          link_preview_options: disableLinkPreview,
         });
       } catch (error) {
         console.error(
@@ -211,12 +217,13 @@ export async function handleEventDeletion(eventId: string, ctx: MyContext) {
     const event = await findEventById(eventId);
 
     if (!event) {
-      await ctx.replyWithMarkdownV2(ctx.t('msg-service-event-not-found'));
+      await ctx.replyWithMarkdownV2(ctx.t('msg-service-event-not-found'), {
+        link_preview_options: disableLinkPreview,
+      });
       console.warn(`Event not found for deletion: ID=${eventId}`);
       return false;
     }
 
-    // Lösche die Nachricht im Kanal, falls vorhanden
     if (event.messageId) {
       try {
         await bot.api.deleteMessage(
@@ -227,7 +234,6 @@ export async function handleEventDeletion(eventId: string, ctx: MyContext) {
           `Message deleted from channel for Event ID=${eventId}, messageId=${event.messageId}`,
         );
       } catch (error) {
-        // Fehler beim Löschen der Nachricht ignorieren oder loggen, aber den Vorgang fortsetzen
         console.error(
           `Error deleting message from channel for Event ID=${eventId}, messageId=${event.messageId}:`,
           error,
@@ -235,7 +241,6 @@ export async function handleEventDeletion(eventId: string, ctx: MyContext) {
       }
     }
 
-    // Lösche das Event aus der Datenbank
     await deleteEventById(eventId);
     console.log(`Event deleted from database: ID=${eventId}`);
 
@@ -244,12 +249,14 @@ export async function handleEventDeletion(eventId: string, ctx: MyContext) {
         icon: ICONS.approve,
         eventTitle: escapeMarkdownV2Text(event.title),
       }),
+      { link_preview_options: disableLinkPreview },
     );
     return true;
   } catch (error) {
     console.error(`Error deleting event ID=${eventId}:`, error);
     await ctx.replyWithMarkdownV2(
       ctx.t('msg-service-event-deletion-error', { icon: ICONS.reject }),
+      { link_preview_options: disableLinkPreview },
     );
     return false;
   }
@@ -297,6 +304,7 @@ export async function postEventToChannel(
           messageText,
           {
             parse_mode: 'MarkdownV2',
+            link_preview_options: disableLinkPreview,
           },
         );
         console.log(
@@ -378,6 +386,7 @@ export async function updateEventInChannel(
             messageText,
             {
               parse_mode: 'MarkdownV2',
+              link_preview_options: disableLinkPreview,
             },
           );
           console.log(`Message edited with ID: ${event.messageId}`);
@@ -393,6 +402,7 @@ export async function updateEventInChannel(
               messageText,
               {
                 parse_mode: 'MarkdownV2',
+                link_preview_options: disableLinkPreview,
               },
             );
             console.log(
@@ -418,6 +428,7 @@ export async function updateEventInChannel(
             messageText,
             {
               parse_mode: 'MarkdownV2',
+              link_preview_options: disableLinkPreview,
             },
           );
           console.log(
@@ -456,10 +467,16 @@ export async function sendSearchToUser(
           ctx.t('msg-service-search-no-events', {
             dateText: escapeMarkdownV2Text(dateText),
           }),
+          {
+            link_preview_options: disableLinkPreview,
+          },
         );
       } catch (error) {
         await ctx.reply(
           ctx.t('msg-service-search-error', { icon: ICONS.reject }),
+          {
+            link_preview_options: disableLinkPreview,
+          },
         );
         console.error(`Error sending message to chatId=${chatId}:`, error);
       }
@@ -491,6 +508,9 @@ export async function sendSearchToUser(
                 icon: ICONS.reject,
                 eventId: event.id,
               }),
+              {
+                link_preview_options: disableLinkPreview,
+              },
             );
             console.error(
               `Error sending photo to user for Event ID=${event.id}:`,
@@ -501,6 +521,7 @@ export async function sendSearchToUser(
           try {
             await bot.api.sendMessage(chatId, message, {
               parse_mode: 'MarkdownV2',
+              link_preview_options: disableLinkPreview,
             });
             console.log(`Message sent to user for Event ID=${event.id}`);
           } catch (error) {
@@ -509,6 +530,9 @@ export async function sendSearchToUser(
                 icon: ICONS.reject,
                 eventId: event.id,
               }),
+              {
+                link_preview_options: disableLinkPreview,
+              },
             );
             console.error(
               `Error sending message to user for Event ID=${event.id}:`,
@@ -522,6 +546,9 @@ export async function sendSearchToUser(
             icon: ICONS.reject,
             eventId: event.id,
           }),
+          {
+            link_preview_options: disableLinkPreview,
+          },
         );
         console.error(`Error processing event ID=${event.id}:`, error);
       }


### PR DESCRIPTION
…vices

- Introduced `disableLinkPreview` option to disable link previews in messages for better user experience.
- Updated `editEventConversation`, `rejectEventConversation`, `searchEventConversation`, `submitEventConversation`, and `notifyAdminsOfEvent` functions to include the new link preview options.
- Ensured consistent handling of link previews in error messages and user prompts throughout the event management workflow.